### PR TITLE
PNDA-49 : support scala-shell and pyflink

### DIFF
--- a/build/upstream-builds/build-flink.sh
+++ b/build/upstream-builds/build-flink.sh
@@ -66,6 +66,21 @@ do
     fi
 
     mvn clean install -DskipTests -Pvendor-repos -Dhadoop.version="${HADOOP_VERSION}"
+
+    if [[ "${HADOOP_DISTRIBUTION}" == "HDP" ]]; then
+	    JAR=$(<../../../upstream-builds/dependencies/upstream-flink-hdp-dependencies.txt)
+	    FLINK_DIR="./flink-dist/target/flink-${FLINK_VERSION}-bin/flink-${FLINK_VERSION}"
+	    FLINK_LIB_DIR="$FLINK_DIR/lib"
+	    if [ -d $FLINK_LIB_DIR ]; then
+		    cd $FLINK_LIB_DIR
+		    wget $JAR
+		    cd -
+            else
+		    echo "$FLINK_LIB_DIR directory is not available "
+		    exit 1
+	    fi
+    fi
+
     tar -cvf flink-${FLINK_VERSION}-${HADOOP_DISTRIBUTION}.tar.gz -C ./flink-dist/target/flink-${FLINK_VERSION}-bin/flink-${FLINK_VERSION} .
     mv ./flink-${FLINK_VERSION}-${HADOOP_DISTRIBUTION}.tar.gz ../pnda-build/
     sha512sum ../pnda-build/flink-${FLINK_VERSION}-${HADOOP_DISTRIBUTION}.tar.gz > ../pnda-build/flink-${FLINK_VERSION}-${HADOOP_DISTRIBUTION}.tar.gz.sha512.txt

--- a/build/upstream-builds/dependencies/upstream-flink-hdp-dependencies.txt
+++ b/build/upstream-builds/dependencies/upstream-flink-hdp-dependencies.txt
@@ -1,0 +1,1 @@
+http://central.maven.org/maven2/com/sun/jersey/jersey-core/1.13-b01/jersey-core-1.13-b01.jar


### PR DESCRIPTION
Add jersey jar to run flink's scala-shell on yarn on HDP setups.